### PR TITLE
Update setting and DA_update repo for using ShadowLevels bump file

### DIFF
--- a/settings_cycle_test
+++ b/settings_cycle_test
@@ -18,6 +18,12 @@ export OUTDIR=${BASEDIR}/cycle_land/${exp_name}/
 
 ############################
 
+# decide if GFSv17
+export GFSv17="NO"
+
+# run (true) ensemble. NO for LETKFOI
+export do_enkf="NO"
+
 # for LETKF, this is size of ensemble.
 # for LETKF-OI pseudo ensemble, or non-ensemble runs use 1 
 export ensemble_size=1
@@ -30,6 +36,7 @@ export atmos_forc=era5
 
 #FV3 resolution
 export RES=96
+export NPZ=127   # vertical layers
 export ORES=mx100
 export TPATH=/scratch2/NCEPDEV/land/data/fix/20231027/C${RES}/
 export TSTUB=C${RES}.${ORES}_oro_data # file stub for orography files in $TPATH
@@ -52,3 +59,7 @@ export DA_config00=${DA_config}
 export DA_config06=${DA_config} 
 export DA_config12=${DA_config} 
 export DA_config18=${DA_config} 
+
+# JEDI nproc--make sure to sync with iolayout
+export NPROC_JEDI=6
+


### PR DESCRIPTION
## Describe your changes  
This PR adds the missing variable setting required by the `do_landDA.sh` in the `NOAA-PSL/land-DA_update` repo. 
This PR also updates the `DA_update` repo for using the `ShadowLevels` bump file in 2Dvar snow DA. 

List any associated PRs  in the submodules.
https://github.com/NOAA-PSL/land-DA_update/pull/31

## Issue ticket number and link
List the git Issue that this PR addresses: 
https://github.com/NOAA-PSL/land-offline_workflow/issues/41

## Test output 
Is this PR expected to pass the DA_IMS_test (ie., does it change the output)? 

Does it pass the DA_IMS_test? 

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 

## Checklist before requesting a review
- [ ] My branch being merged is up to date with the latest develop. 
- [ ] I have performed a self-review of my code by examining the differences that will be merged.
- [ ] I have not made any unnecessary code changes / changed any default behavior.
- [ ] My code passes the DA_IMS_test, or differences can be explained. 

