### PR TITLE
Overwrite background restart with analysis restart after DA and before tile2vector

### DIFF
--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -le 
 #SBATCH --job-name=offline_noahmp
-#SBATCH --account=da-cpu
+#SBATCH --account=gsienkf
 #SBATCH --qos=debug
 #SBATCH --nodes=6
 #SBATCH --tasks-per-node=20

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -le 
 #SBATCH --job-name=offline_noahmp
-#SBATCH --account=gsienkf
+#SBATCH --account=da-cpu
 #SBATCH --qos=debug
 #SBATCH --nodes=6
 #SBATCH --tasks-per-node=20
@@ -199,7 +199,15 @@ while [ $date_count -lt $cycles_per_job ]; do
 
 	cp ${WORKDIR}/tile2vector.namelist $MEM_WORKDIR/tile2vector.namelist
 
+        #overwrite background tile restart with analysis tile restart before converting
         cd $MEM_WORKDIR
+        ANAL_TILEFILE_BASE="../jedi/anl/${YYYY}${MM}${DD}.${HH}0000.sfc_data.tile"
+        for i in 1 2 3 4 5 6; do
+          file="${ANAL_TILEFILE_BASE}${i}.nc"
+          if [ -f "$file" ]; then
+            cp $file .
+          fi
+        done
 
         $vec2tileexec tile2vector.namelist
         if [[ $? != 0 ]]; then

--- a/template.ufs-noahMP.namelist.era5
+++ b/template.ufs-noahMP.namelist.era5
@@ -58,7 +58,7 @@
  canopy_stomatal_resistance_option = 2
  soil_wetness_option               = 1
  runoff_option                     = 1
- surface_exchange_option           = 3
+ surface_exchange_option           = 3 
  supercooled_soilwater_option      = 1
  frozen_soil_adjust_option         = 1
  radiative_transfer_option         = 3
@@ -67,9 +67,9 @@
  soil_temp_lower_bdy_option        = 2
  soil_temp_time_scheme_option      = 3
  thermal_roughness_scheme_option   = 2
- surface_evap_resistance_option    = 1
- glacier_option                    = 1
- tq_diagnostic_option              = 3
+ surface_evap_resistance_option    = 4 
+ glacier_option                    = 2 
+ tq_diagnostic_option              = 2 
 /
 
 &forcing

--- a/template.ufs-noahMP.namelist.era5
+++ b/template.ufs-noahMP.namelist.era5
@@ -58,7 +58,7 @@
  canopy_stomatal_resistance_option = 2
  soil_wetness_option               = 1
  runoff_option                     = 1
- surface_exchange_option           = 3 
+ surface_exchange_option           = 3
  supercooled_soilwater_option      = 1
  frozen_soil_adjust_option         = 1
  radiative_transfer_option         = 3
@@ -67,9 +67,9 @@
  soil_temp_lower_bdy_option        = 2
  soil_temp_time_scheme_option      = 3
  thermal_roughness_scheme_option   = 2
- surface_evap_resistance_option    = 4 
- glacier_option                    = 2 
- tq_diagnostic_option              = 2 
+ surface_evap_resistance_option    = 4
+ glacier_option                    = 2
+ tq_diagnostic_option              = 2
 /
 
 &forcing


### PR DESCRIPTION
## Describe your changes  
Summarise all code changes included in PR: 
1. overwrite background restart files (in tiles) with analysis restart files (in tiles) after land DA is done and before tile2vector in the workdir/mem000
2. modify noah-mp options to be consistent with Mike's spin-up script

List any associated PRs  in the submodules.
N/A

## Issue ticket number and link
List the git Issue that this PR addresses: 
https://github.com/NOAA-PSL/land-offline_workflow/issues/70
https://github.com/NOAA-PSL/land-offline_workflow/issues/71

## Test output 
Is this PR expected to pass the snowDA_SFCSNO_GHCN_IMS_test (ie., does it change the output)? 
Yes. It will change the output.
Does it pass the snowDA_SFCSNO_GHCN_IMS_test? 

If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 

## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [x] My code passes the snowDA_test, or differences can be explained. 

