### PR TITLE
Add regression tests capability to Gaea C6

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ COMPILING and TESTING.
  
 > do_submit_test.sh 
 
-Once completed, to check snow DA output:
-
-> (For snowDA) check_snowDA_test.sh
+> A suite of regression tests can be found in the reg_tests directory
 
 RUNNING YOUR OWN EXPERIMENTS 
 

--- a/do_submit_cycle.sh
+++ b/do_submit_cycle.sh
@@ -28,7 +28,7 @@ if [[ ${MACHINE_ID} == 'ursa' ]]; then
     export COMINobsforge_prfx=/scratch3/NCEPDEV/global/role.glopara/dump_ioda/
 elif [[ ${MACHINE_ID} == 'gaeac6' ]]; then
     echo "running land offline workflow on GAEA C6"
-    export DATADIR=/gpfs/f6/land-cpu/proj-shared/DATA/   
+    export DATADIR=/gpfs/f6/land-cpu/world-shared/DATA/   
     export landmods=land_mods_gaeac6
     export stochymods=stochy_mods_gaeac6
 	export COMINobsproc_prfx=/gpfs/f6/drsa-precip3/world-shared/role.glopara/dump/        #gdas.${YYYY}${MM}${DD}/${HH}/atmos

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -18,9 +18,7 @@ List the git Issue that this PR addresses:
 
 
 ## Test output 
-Is this PR expected to pass the snowDA_SFCSNO_GHCN_IMS_test (ie., does it change the output)? 
-
-Does it pass the snowDA_SFCSNO_GHCN_IMS_test? 
+Is this PR expected to pass the reg_test suite (ie., does it change the output)? 
 
 If changes to the test results are expected, what are these changes? Provide a link to the output directory when running the test: 
 
@@ -28,5 +26,5 @@ If changes to the test results are expected, what are these changes? Provide a l
 - [ ] My branch being merged is up to date with the latest develop. 
 - [ ] I have performed a self-review of my code by examining the differences that will be merged.
 - [ ] I have not made any unnecessary code changes / changed any default behavior.
-- [ ] My code passes the snowDA_test, or differences can be explained. 
+- [ ] My code passes the reg_test, or differences can be explained. 
 

--- a/reg_tests/README.md
+++ b/reg_tests/README.md
@@ -1,6 +1,6 @@
 # README: Flexible Regression Test Suite (rt.sh)
 
-After compilations are done, this script (rt.sh) automates the execution of regression test scenarios for the workflow. It manages configuration staging, Slurm job submission, queue monitoring, and final validation. Currently only supported on Ursa.
+After compilations are done, this script (rt.sh) automates the execution of regression test scenarios for the workflow. It manages configuration staging, Slurm job submission, queue monitoring, and final validation. Currently only supported on Ursa and Gaea C6.
 
 Author: Yuan Xue (yuan.xue@noaa.gov)
 Date: 06/18/2026

--- a/reg_tests/check_C96_2dvar_snowDA_test.sh
+++ b/reg_tests/check_C96_2dvar_snowDA_test.sh
@@ -10,8 +10,21 @@ if [[ -z "${OUTDIR}" ]]; then
     exit 1
 fi
 
-TEST_BASEDIR="/scratch4/NCEPDEV/land/data/DA/offline_workflow/baseline/ims_2dvar/vector"
+dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+GDASApp_root=${dir_root}/../DA_update/GDASApp/
+source $GDASApp_root/ush/detect_machine.sh
 
+if [[ ${MACHINE_ID} == 'ursa' ]]; then
+    echo "checking reg_tests on URSA"
+    TEST_BASEDIR="/scratch4/NCEPDEV/land/data/DA/offline_workflow/baseline/ims_2dvar/vector"
+elif [[ ${MACHINE_ID} == 'gaeac6' ]]; then
+    echo "checking reg_tests on GAEA C6"
+    TEST_BASEDIR="/gpfs/f6/land-cpu/world-shared/Yuan.Xue/offline_workflow/baseline/ims_2dvar/vector"
+else
+    echo "reg_tests currently supported only on URSA and GAEA C6"
+    exit 1
+fi
+    
 for TEST_DATE in 2024-03-01_00-00-00 2024-03-02_00-00-00 
 do
     for state in back anal 

--- a/reg_tests/check_C96_letkf_snowDA_test.sh
+++ b/reg_tests/check_C96_letkf_snowDA_test.sh
@@ -10,8 +10,20 @@ if [[ -z "${OUTDIR}" ]]; then
     exit 1
 fi
 
-# Base directory for the baseline datasets
-TEST_BASE_ROOT="/scratch4/NCEPDEV/land/data/DA/offline_workflow/baseline/ens20_ghcn_letkf"
+dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+GDASApp_root=${dir_root}/../DA_update/GDASApp/
+source $GDASApp_root/ush/detect_machine.sh
+
+if [[ ${MACHINE_ID} == 'ursa' ]]; then
+    echo "checking reg_tests on URSA"
+    TEST_BASE_ROOT="/scratch4/NCEPDEV/land/data/DA/offline_workflow/baseline/ens20_ghcn_letkf"
+elif [[ ${MACHINE_ID} == 'gaeac6' ]]; then
+    echo "checking reg_tests on GAEA C6"
+    TEST_BASE_ROOT="/gpfs/f6/land-cpu/world-shared/Yuan.Xue/offline_workflow/baseline/ens20_ghcn_letkf"
+else
+    echo "reg_tests currently supported only on URSA and GAEA C6"
+    exit 1
+fi
 
 # Loop through members 001 to 020 using Bash brace expansion
 for i in {001..020}

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -317,7 +317,7 @@ while [ $date_count -lt $cycles_per_job ]; do
             cd $MEM_WORKDIR
                 
             #TODO: modify NoahMP to have mpi-group for each ensemble member and compare runtimes
-            time srun '--export=ALL' --exclusive --label -K -n ${NPROC_NOMP} --mem-per-cpu ${SLURM_MEM_PER_CPU} $LSMexec   &
+            time srun '--export=ALL' --label -K -n ${NPROC_NOMP} $LSMexec   &
             # #-N1-1 --exclusive
     
             # TODO: Modify noahmp to exit with error code    


### PR DESCRIPTION
## Describe your changes  
Summarise all code changes included in PR: 
1. Add baseline testcase paths for Gaea C6
2. Remove several srun flags for Gaea C6 because "mem-per-cpu" is not permitted on gaea c6 and "--exclusive" has to remove altogether with "mem-per-cpu" on Gaea C6 in submit_cycle.sh (confirmed that removing flags does not impact Ursa runs)

List any associated PRs in the submodules.
N/A

## Issue ticket number and link
List the git Issue that this PR addresses: 
https://github.com/NOAA-PSL/land-offline_workflow/issues/90

## Checklist before requesting a review
- [x] My branch being merged is up to date with the latest develop. 
- [x] I have performed a self-review of my code by examining the differences that will be merged.
- [x] I have not made any unnecessary code changes / changed any default behavior.
- [x] My code passes the snowDA_test, or differences can be explained. 

